### PR TITLE
Fix data race when rewriting 'vbytes' while reading it

### DIFF
--- a/bump/bump.go
+++ b/bump/bump.go
@@ -74,15 +74,13 @@ func bump(c *cli.Context) error {
 	}
 	fmt.Println("New version:", v)
 
-	loc1 := loc[1]
 	len1 := loc[1] - loc[0]
-	// fmt.Println("len1:", len1, len(v.String()))
-	if len(v.String()) > len1 {
-		loc1 += len(v.String()) - len1
-	}
-	b := vbytes[:loc[0]]
-	b = append(b, []byte(v.String())...)
-	b = append(b, vbytes[loc1:]...)
+	additionalBytes := len(v.String()) - len1
+	// Create and fill an extended buffer
+	b := make([]byte, len(vbytes) + additionalBytes)
+	copy(b[:loc[0]], vbytes[:loc[0]])
+	copy(b[loc[0]:loc[1]+additionalBytes], v.String())
+	copy(b[loc[1]+additionalBytes:], vbytes[loc[1]:])
 	// fmt.Println("writing:", string(b))
 
 	err = ioutil.WriteFile(filename, b, 0644)


### PR DESCRIPTION
PR #1 introduced a bug whereby when the version string increases in size it overwrites existing bytes in the version file. This is due to a data race on the `vbytes` buffer, which is taken as a slice and therefore reused.

This change creates and fills a new buffer so that no data race occurs.